### PR TITLE
fix: use v8::Local instead of v8::Handle

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -13,10 +13,10 @@ void IsValidWindow(const Nan::FunctionCallbackInfo<v8::Value>& info) {
                                                 node::Buffer::Length(info[0])));
 }
 
-void Init(v8::Handle<v8::Object> exports) {
+void Init(v8::Local<v8::Object> exports) {
   Nan::SetMethod(exports, "isValidWindow", IsValidWindow);
 }
 
 }  // namespace
 
-NODE_MODULE(is_valid_window, Init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
The alias is not available when built with `V8_IMMINENT_DEPRECATION_WARNINGS`

Fixes https://github.com/electron/electron/pull/16138/commits/16b3634af20880c9af40ea6334fa6d0c8faa96de

/cc @zcbenz 