### PR TITLE
refactor: use napi

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,9 +16,6 @@
         'src/impl.h',
         'src/main.cc',
       ],
-      'include_dirs': [
-        '<!(node -e "require(\'nan\')")'
-      ],
       'conditions': [
         ['OS=="win"', {
           'sources': [

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,22 +1,56 @@
+#include <js_native_api.h>
+#include <node_api.h>
+
 #include "impl.h"
-#include "nan.h"
 
 namespace {
 
-void IsValidWindow(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  if (!node::Buffer::HasInstance(info[0])) {
-    Nan::ThrowTypeError("First argument must be Buffer");
-    return;
+napi_value IsValidWindow(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1], result;
+  napi_status status;
+
+  status = napi_get_cb_info(env, info, &argc, args, NULL, NULL);
+  if (status != napi_ok)
+    return NULL;
+
+  bool is_buffer;
+  status = napi_is_buffer(env, args[0], &is_buffer);
+  if (status != napi_ok)
+    return NULL;
+
+  if (!is_buffer) {
+    napi_throw_error(env, NULL, "First argument must be Buffer");
+    return NULL;
   }
 
-  info.GetReturnValue().Set(impl::IsValidWindow(node::Buffer::Data(info[0]),
-                                                node::Buffer::Length(info[0])));
+  char* data;
+  size_t length;
+  status = napi_get_buffer_info(env, args[0], (void**)&data, &length);
+  if (status != napi_ok)
+    return NULL;
+
+  status = napi_get_boolean(env, impl::IsValidWindow(data, length), &result);
+  if (status != napi_ok)
+    return NULL;
+
+  return result;
 }
 
-void Init(v8::Local<v8::Object> exports) {
-  Nan::SetMethod(exports, "isValidWindow", IsValidWindow);
+napi_value Init(napi_env env, napi_value exports) {
+  napi_status status;
+  napi_property_descriptor descriptors[] = {{"isValidWindow", NULL,
+                                             IsValidWindow, NULL, NULL, NULL,
+                                             napi_default, NULL}};
+
+  status = napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors);
+  if (status != napi_ok)
+    return NULL;
+
+  return exports;
 }
 
 }  // namespace
 
-NODE_MODULE(NODE_GYP_MODULE_NAME, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
NAN needs api update for v8 7.4 

CI : https://circleci.com/gh/electron/electron/139635

```
In file included from ../src/main.cc:2:
In file included from ../../nan/nan.h:222:
In file included from ../../nan/nan_new.h:189:
../../nan/nan_implementation_12_inl.h:103:42: error: no viable conversion from 'v8::Isolate *' to 'Local<v8::Context>'
  return scope.Escape(v8::Function::New( isolate
                                         ^~~~~~~
/Users/electrontest/github/electron-gn/src/out/Testing/gen/node_headers/include/node/v8.h:181:7: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'v8::Isolate *'
      to 'const v8::Local<v8::Context> &' for 1st argument
class Local {
      ^
/Users/electrontest/github/electron-gn/src/out/Testing/gen/node_headers/include/node/v8.h:181:7: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'v8::Isolate *'
      to 'v8::Local<v8::Context> &&' for 1st argument
/Users/electrontest/github/electron-gn/src/out/Testing/gen/node_headers/include/node/v8.h:185:13: note: candidate template ignored: could not match 'Local<type-parameter-0-0>' against 'v8::Isolate *'
  V8_INLINE Local(Local<S> that)
            ^
/Users/electrontest/github/electron-gn/src/out/Testing/gen/node_headers/include/node/v8.h:4162:22: note: passing argument to parameter 'context' here
      Local<Context> context, FunctionCallback callback,
```

this unblocks building the module for chromium 74 upgrade https://github.com/electron/electron/pull/17088